### PR TITLE
Switched to AsyncKeyedLock

### DIFF
--- a/Tellma.Client/Tellma.Client.csproj
+++ b/Tellma.Client/Tellma.Client.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.1.1" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.2.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />

--- a/Tellma.Client/Tellma.Client.csproj
+++ b/Tellma.Client/Tellma.Client.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />

--- a/Tellma.Client/Tellma.Client.csproj
+++ b/Tellma.Client/Tellma.Client.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.1.0" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.1.1" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />

--- a/Tellma.Client/Tellma.Client.csproj
+++ b/Tellma.Client/Tellma.Client.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.1.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />


### PR DESCRIPTION
Switched to AsyncKeyedLock which is able to clean up the dictionary for single threaded scopes.